### PR TITLE
Add Jest test framework

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+Thank you for considering contributing to this project!
+
+## Running the Test Suite
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run all tests:
+   ```bash
+   npm test
+   ```
+
+Jest will automatically find files ending in `.test.ts` under `src/`.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Running Tests
+
+This project uses Jest for unit testing. After installing dependencies with `npm install`, run:
+
+```bash
+npm test
+```
+
+All test files are located beside the code under `src/`.

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "jest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -59,7 +60,10 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/jest": "^29.5.5",
     "genkit-cli": "^1.8.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"

--- a/src/ai/flows/polish-note-flow.test.ts
+++ b/src/ai/flows/polish-note-flow.test.ts
@@ -1,0 +1,20 @@
+import {jest} from '@jest/globals';
+
+// Mock the genkit ai instance so that defineFlow returns our implementation
+jest.unstable_mockModule('@/ai/genkit', () => {
+  return {
+    ai: {
+      definePrompt: jest.fn(() => async () => ({output: {polishedNote: 'Polished'}})),
+      defineFlow: jest.fn((_cfg, fn) => fn),
+    },
+  };
+});
+
+const {polishNote} = await import('./polish-note-flow');
+
+describe('polishNoteFlow', () => {
+  it('returns polished text', async () => {
+    const result = await polishNote({rawNote: 'hello'});
+    expect(result).toEqual({polishedNote: 'Polished'});
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependencies and a test script
- document how to run tests
- provide contributing notes
- create Jest config for TypeScript/ESM
- add example test for the polish note flow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684090007b348323a2b6a25a7a8c0091