### PR TITLE
Add aria-label to sidebar toggle

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -271,6 +271,7 @@ const SidebarTrigger = React.forwardRef<
       data-sidebar="trigger"
       variant="ghost"
       size="icon"
+      aria-label="Toggle Sidebar"
       className={cn("h-7 w-7", className)}
       onClick={(event) => {
         onClick?.(event)


### PR DESCRIPTION
## Summary
- improve accessibility by labeling the sidebar toggle button

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run typecheck --silent` *(fails: modules not found)*
- `npx lighthouse https://example.com --quiet --chrome-flags="--headless"` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840e64c8610832395439149bb0a9d2a