### PR TITLE
Add unit tests for flows and components

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,7 @@
 export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   extensionsToTreatAsEsm: ['.ts', '.tsx'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
     "ts-jest": "^29.1.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/src/ai/flows/generate-daily-affirmation.test.ts
+++ b/src/ai/flows/generate-daily-affirmation.test.ts
@@ -1,0 +1,33 @@
+import {jest} from '@jest/globals';
+
+const prompt = jest.fn();
+
+jest.unstable_mockModule('@/ai/genkit', () => ({
+  ai: {
+    definePrompt: jest.fn(() => prompt),
+    defineFlow: jest.fn((_cfg, fn) => fn),
+  },
+}));
+
+let generateDailyAffirmation;
+
+describe('generateDailyAffirmationFlow', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    prompt.mockReset();
+    ({generateDailyAffirmation} = await import('./generate-daily-affirmation'));
+  });
+
+  it('returns affirmation text', async () => {
+    const expected = {affirmation: 'You are great'};
+    prompt.mockResolvedValue({output: expected});
+    const result = await generateDailyAffirmation({loggedData: 'log', currentDate: '2020-01-01'});
+    expect(result).toEqual(expected);
+  });
+
+  it('propagates errors from prompt', async () => {
+    const error = new Error('boom');
+    prompt.mockRejectedValue(error);
+    await expect(generateDailyAffirmation({loggedData: 'log', currentDate: '2020-01-01'})).rejects.toThrow('boom');
+  });
+});

--- a/src/ai/flows/generate-spoken-insight.test.ts
+++ b/src/ai/flows/generate-spoken-insight.test.ts
@@ -1,0 +1,44 @@
+import {jest} from '@jest/globals';
+
+const prompt = jest.fn();
+
+jest.unstable_mockModule('@/ai/genkit', () => ({
+  ai: {
+    definePrompt: jest.fn(() => prompt),
+    defineFlow: jest.fn((_cfg, fn) => fn),
+  },
+}));
+
+let generateSpokenInsight;
+
+describe('generateSpokenInsightFlow', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    prompt.mockReset();
+    ({generateSpokenInsight} = await import('./generate-spoken-insight'));
+  });
+
+  it('returns spoken insight', async () => {
+    const expected = {spokenInsight: 'hello'};
+    prompt.mockResolvedValue({output: expected});
+    const result = await generateSpokenInsight({
+      interpretationContent: {theMessage: '', spiritualSignificance: '', ancientWisdom: '', context: '', quote: '', metaphor: '', reflectionQuestion: ''},
+      sourceLanguage: 'English',
+      targetLanguage: 'English',
+      voiceStyle: 'Calm',
+    });
+    expect(result).toEqual(expected);
+  });
+
+  it('throws when no output', async () => {
+    prompt.mockResolvedValue({output: undefined});
+    await expect(
+      generateSpokenInsight({
+        interpretationContent: {theMessage: '', spiritualSignificance: '', ancientWisdom: '', context: '', quote: '', metaphor: '', reflectionQuestion: ''},
+        sourceLanguage: 'English',
+        targetLanguage: 'English',
+        voiceStyle: 'Calm',
+      })
+    ).rejects.toThrow('Failed to generate spoken insight from AI model.');
+  });
+});

--- a/src/ai/flows/interpret-angel-number.test.ts
+++ b/src/ai/flows/interpret-angel-number.test.ts
@@ -1,0 +1,42 @@
+import {jest} from '@jest/globals';
+
+const prompt = jest.fn();
+
+jest.unstable_mockModule('@/ai/genkit', () => ({
+  ai: {
+    definePrompt: jest.fn(() => prompt),
+    defineFlow: jest.fn((_cfg, fn) => fn),
+  },
+}));
+
+let interpretAngelNumber;
+
+describe('interpretAngelNumberFlow', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    prompt.mockReset();
+    ({interpretAngelNumber} = await import('./interpret-angel-number'));
+  });
+
+  it('returns interpretation', async () => {
+    const expected = {
+      theMessage: 'msg',
+      spiritualSignificance: 'sig',
+      ancientWisdom: 'anc',
+      context: 'ctx',
+      quote: 'quote',
+      metaphor: 'met',
+      reflectionQuestion: 'ref',
+    };
+    prompt.mockResolvedValue({output: expected});
+    const result = await interpretAngelNumber({number: 1, emotion: 'Joyful', activity: 'Meditating', notes: '', targetLanguage: 'English'});
+    expect(result).toEqual(expected);
+  });
+
+  it('throws when no output', async () => {
+    prompt.mockResolvedValue({output: undefined});
+    await expect(
+      interpretAngelNumber({number: 1, emotion: 'Joyful', activity: 'Meditating', notes: '', targetLanguage: 'English'})
+    ).rejects.toThrow('Failed to get interpretation from AI model.');
+  });
+});

--- a/src/ai/flows/polish-note-flow.test.ts
+++ b/src/ai/flows/polish-note-flow.test.ts
@@ -1,20 +1,32 @@
 import {jest} from '@jest/globals';
 
-// Mock the genkit ai instance so that defineFlow returns our implementation
-jest.unstable_mockModule('@/ai/genkit', () => {
-  return {
-    ai: {
-      definePrompt: jest.fn(() => async () => ({output: {polishedNote: 'Polished'}})),
-      defineFlow: jest.fn((_cfg, fn) => fn),
-    },
-  };
-});
+const prompt = jest.fn();
 
-const {polishNote} = await import('./polish-note-flow');
+jest.unstable_mockModule('@/ai/genkit', () => ({
+  ai: {
+    definePrompt: jest.fn(() => prompt),
+    defineFlow: jest.fn((_cfg, fn) => fn),
+  },
+}));
+
+let polishNote;
 
 describe('polishNoteFlow', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    prompt.mockReset();
+    ({polishNote} = await import('./polish-note-flow'));
+  });
+
   it('returns polished text', async () => {
+    const expected = {polishedNote: 'Polished'};
+    prompt.mockResolvedValue({output: expected});
     const result = await polishNote({rawNote: 'hello'});
-    expect(result).toEqual({polishedNote: 'Polished'});
+    expect(result).toEqual(expected);
+  });
+
+  it('throws when no output', async () => {
+    prompt.mockResolvedValue({output: undefined});
+    await expect(polishNote({rawNote: 'hello'})).rejects.toThrow('Failed to polish note using AI model.');
   });
 });

--- a/src/components/__tests__/LogEntryForm.test.tsx
+++ b/src/components/__tests__/LogEntryForm.test.tsx
@@ -1,0 +1,78 @@
+/** @jest-environment jsdom */
+import {jest} from '@jest/globals';
+import React from 'react';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const interpretAngelNumber = jest.fn();
+jest.unstable_mockModule('@/ai/flows/interpret-angel-number', () => ({interpretAngelNumber}));
+jest.unstable_mockModule('@/ai/flows/generate-spoken-insight', () => ({generateSpokenInsight: jest.fn()}));
+jest.unstable_mockModule('@/ai/flows/polish-note-flow', () => ({polishNote: jest.fn()}));
+
+const toast = jest.fn();
+jest.unstable_mockModule('@/hooks/use-toast', () => ({useToast: () => ({toast})}));
+
+let LogEntryForm;
+
+const interpretation = {
+  theMessage: 'msg',
+  spiritualSignificance: 'sig',
+  ancientWisdom: 'anc',
+  context: 'ctx',
+  quote: 'quote',
+  metaphor: 'met',
+  reflectionQuestion: 'ref',
+};
+
+describe('LogEntryForm', () => {
+  beforeEach(async () => {
+    jest.resetModules();
+    interpretAngelNumber.mockReset();
+    ({LogEntryForm} = await import('../LogEntryForm'));
+  });
+
+  it('submits valid data', async () => {
+    interpretAngelNumber.mockResolvedValue(interpretation);
+    const onLogEntry = jest.fn();
+    const user = userEvent.setup();
+    render(<LogEntryForm onLogEntry={onLogEntry} />);
+
+    await user.type(screen.getByLabelText(/angel number/i), '123');
+
+    await user.click(screen.getByLabelText(/your emotion/i));
+    await user.click(screen.getByText('Joyful'));
+
+    await user.click(screen.getByLabelText(/your activity/i));
+    await user.click(screen.getByText('Meditating'));
+
+    await user.click(screen.getByRole('button', {name: /decode/i}));
+
+    await waitFor(() => expect(onLogEntry).toHaveBeenCalled());
+    expect(onLogEntry.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        angelNumber: '123',
+        emotion: 'Joyful',
+        activity: 'Meditating',
+        interpretation,
+        interpretationLanguage: 'English',
+      })
+    );
+  });
+
+  it('shows error for invalid angel number', async () => {
+    const onLogEntry = jest.fn();
+    const user = userEvent.setup();
+    render(<LogEntryForm onLogEntry={onLogEntry} />);
+
+    await user.type(screen.getByLabelText(/angel number/i), 'abc');
+    await user.click(screen.getByLabelText(/your emotion/i));
+    await user.click(screen.getByText('Joyful'));
+    await user.click(screen.getByLabelText(/your activity/i));
+    await user.click(screen.getByText('Meditating'));
+
+    await user.click(screen.getByRole('button', {name: /decode/i}));
+
+    expect(await screen.findByText('Invalid angel number format.')).toBeInTheDocument();
+    expect(onLogEntry).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/TimelineEntryCard.test.tsx
+++ b/src/components/__tests__/TimelineEntryCard.test.tsx
@@ -1,0 +1,43 @@
+/** @jest-environment jsdom */
+import {jest} from '@jest/globals';
+import React from 'react';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+jest.unstable_mockModule('@/hooks/use-toast', () => ({useToast: () => ({toast: jest.fn()})}));
+
+let TimelineEntryCard;
+
+describe('TimelineEntryCard', () => {
+  const entry = {
+    id: '1',
+    timestamp: new Date().toISOString(),
+    angelNumber: '123',
+    emotion: 'Joyful',
+    activity: 'Meditating',
+    interpretationLanguage: 'English',
+  } as any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    ({TimelineEntryCard} = await import('../TimelineEntryCard'));
+  });
+
+  it('triggers edit handler', async () => {
+    const onEdit = jest.fn();
+    const user = userEvent.setup();
+    render(<TimelineEntryCard entry={entry} onEdit={onEdit} onDelete={jest.fn()} />);
+    await user.click(screen.getByLabelText(/edit/i));
+    expect(onEdit).toHaveBeenCalledWith(entry);
+  });
+
+  it('triggers delete handler after confirmation', async () => {
+    const onDelete = jest.fn();
+    const user = userEvent.setup();
+    render(<TimelineEntryCard entry={entry} onEdit={jest.fn()} onDelete={onDelete} />);
+    await user.click(screen.getByLabelText(/delete/i));
+    const confirm = await screen.findByRole('button', {name: /yes, delete it/i});
+    await user.click(confirm);
+    expect(onDelete).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest with setup file
- add RTL setup with jest-dom
- install React Testing Library dependencies
- expand polish note tests to cover error handling
- add tests for all flows
- add component tests for LogEntryForm and TimelineEntryCard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e62c3c4883238e149427c9719313